### PR TITLE
Remove --noinput flag when running unit tests.

### DIFF
--- a/src/unittest/DisqusUnitTestEngine.php
+++ b/src/unittest/DisqusUnitTestEngine.php
@@ -38,7 +38,7 @@ class DisqusUnitTestEngine extends ArcanistBaseUnitTestEngine {
       return array();
     }
 
-    $args = array('python', 'runtests.py', '--noinput', '--with-quickunit',
+    $args = array('python', 'runtests.py', '--with-quickunit',
               '--quickunit-output="test_results/coverage.json"',
               '--with-json', '--json-file="test_results/nosetests.json"');
 


### PR DESCRIPTION
I have a patch pending to remove this flag. Once it is accepted we should stop using it in arcanist.
