### PR TITLE
Complete previous commit

### DIFF
--- a/src/unittest/PythonBaseUnitTestEngine.php
+++ b/src/unittest/PythonBaseUnitTestEngine.php
@@ -157,8 +157,8 @@ abstract class PythonBaseUnitTestEngine extends ArcanistUnitTestEngine {
 
     private function parseXunitFile($xunit_path, $results) {
 
-        $this->parser = new ArcanistXUnitTestResultParser();
-        return  $this->parser->parseTestResults(
+        $parser = new ArcanistXUnitTestResultParser();
+        return  $parser->parseTestResults(
             Filesystem::readFile($xunit_path));
     }
 


### PR DESCRIPTION
The latest version of `arc` started throwing an error and quitting when
using unit test results via `arc diff` or `arc unit` by saying `Attempt
to write to undeclared property parser`.

Commit a9c75eb attempted to fix this, but was incomplete. This patch
attempts to fix the 'Attempt to write to undeclared property' error
again, by completing the previous commit.