### PR TITLE
Pass number to `setDuration`

### DIFF
--- a/src/unittest/PythonBaseUnitTestEngine.php
+++ b/src/unittest/PythonBaseUnitTestEngine.php
@@ -261,7 +261,7 @@ abstract class PythonBaseUnitTestEngine extends ArcanistUnitTestEngine {
         $result->setNamespace('coverage');
         $result->setName('coverage');
         $result->setResult('pass');
-        $result->setDuration("$time");
+        $result->setDuration($time);
         $result->setUserData(
             "coverage: $lines_percentage% executable: $lines_executable / covered: $lines_covered"
         );


### PR DESCRIPTION
Since Jul 15, `setDuration` in Arcanist throws an error unless an
integer or a float is passed [1]. Change the only use of `setDuration`
to pass a number instead of a string.

[1] https://secure.phabricator.com/D13637